### PR TITLE
36. Valid Sudoku

### DIFF
--- a/CP and LEETCODE/Shanit/Leetcode Problem 53/Sudoku.java
+++ b/CP and LEETCODE/Shanit/Leetcode Problem 53/Sudoku.java
@@ -1,0 +1,18 @@
+class Solution {
+    public boolean isValidSudoku(char[][] board) {
+        Set<String> check = new HashSet<>();
+        for(int i = 0; i < 9; i++){
+            for(int j = 0; j < 9; j++){
+                int n=board[i][j];
+                if(n != '.'){
+                    if(!check.add(n + "in row" + i) || 
+                       !check.add(n + "in col" + j) || 
+                       !check.add(n+" in box"+i/3+"-"+j/3)){
+                        return false;
+                    }
+                }
+            }
+        } 
+        return true;  
+    }
+}


### PR DESCRIPTION
Determine if a 9 x 9 Sudoku board is valid. Only the filled cells need to be validated according to the following rules:

Each row must contain the digits 1-9 without repetition. Each column must contain the digits 1-9 without repetition. Each of the nine 3 x 3 sub-boxes of the grid must contain the digits 1-9 without repetition. Note:

1. A Sudoku board (partially filled) could be valid but is not necessarily solvable.
2. Only the filled cells need to be validated according to the mentioned rules.